### PR TITLE
make header image responsive

### DIFF
--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -3,7 +3,8 @@ layout: default
 ---
 
 <div id ="headerimg">  
-  <img src ="/assets/images/happybodies.png"/></div>
+  <img src ="/assets/images/happybodies.png" style="max-width:100%;"/>
+</div>
 
 <div id="main" role="main">
   

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -10,8 +10,6 @@
 }
 
 #headerimg{
-	width: 120%;
-	min-width: 1500px;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
posts initially had divs tied to them, as it's been a few months since i last checked up on the site I've forgotten what I had initially planned on with the post divs. So instead I opted to change the header img to be more responsive on mobile and in browsers